### PR TITLE
Set environment variables to only expose allocated devices

### DIFF
--- a/cmd/k8s-device-plugin/main.go
+++ b/cmd/k8s-device-plugin/main.go
@@ -202,7 +202,7 @@ func (p *Plugin) Allocate(ctx context.Context, r *pluginapi.AllocateRequest) (*p
 		car = pluginapi.ContainerAllocateResponse{
 			Envs: map[string]string{
 				"HIP_VISIBLE_DEVICES": strings.Join(HipDeviceIDs, ","),
-				"GPU_DEVICE_ORDINAL":  strings.Join(HipDevicesIDs, ","),
+				"GPU_DEVICE_ORDINAL":  strings.Join(HipDeviceIDs, ","),
 			},
 		}
 


### PR DESCRIPTION
Set both HIP and OpenCL environment variables for devices
to be exposed. The device ordinals are calculated from the
sorted PCI addresses. Tested on machines with dual AMD
and NVIDIA cards where the ROCm GPUs in the system were
identified as cards #2 and #4.

Note that for pods not requesting any devices this code will
never be called, so unless you set the default exposed devices
all of them will be exposed.