### PR TITLE
Update rbac to v1

### DIFF
--- a/k8s-ds-amdgpu-dp-health.yaml
+++ b/k8s-ds-amdgpu-dp-health.yaml
@@ -4,6 +4,49 @@
 #
 # ***** this requires --allow-privileged=true set for both kube-apiserver and kubelet
 #
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: radeon
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: radeon-role
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - radeon-role
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - watch
+  - get
+  - list
+  - update
+  resourceNames:
+  - radeon-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: radeon-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: radeon-labeller-role
+subjects:
+- kind: ServiceAccount
+  name: radeon-role
+  namespace: default
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -20,6 +63,7 @@ spec:
       labels:
         name: amdgpu-dp-ds
     spec:
+      serviceAccount: radeon
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/k8s-ds-amdgpu-dp.yaml
+++ b/k8s-ds-amdgpu-dp.yaml
@@ -1,3 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: radeon
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: radeon-role
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - radeon-role
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - watch
+  - get
+  - list
+  - update
+  resourceNames:
+  - radeon-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: radeon-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: radeon-labeller-role
+subjects:
+- kind: ServiceAccount
+  name: radeon-role
+  namespace: default
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -14,6 +57,7 @@ spec:
       labels:
         name: amdgpu-dp-ds
     spec:
+      serviceAccount: radeon
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/k8s-ds-amdgpu-dp.yaml
+++ b/k8s-ds-amdgpu-dp.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: radeon
+  name: amd-gpu
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: radeon-role
+  name: amd-gpu-role
 rules:
 - apiGroups:
   - policy
@@ -15,7 +15,7 @@ rules:
   verbs:
   - use
   resourceNames:
-  - radeon-role
+  - amd-gpu-role
 - apiGroups:
   - ""
   resources:
@@ -26,19 +26,19 @@ rules:
   - list
   - update
   resourceNames:
-  - radeon-role
+  - amd-gpu-role
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: radeon-rolebinding
+  name: amd-gpu-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: radeon-labeller-role
+  name: amd-gpu-labeller-role
 subjects:
 - kind: ServiceAccount
-  name: radeon-role
+  name: amd-gpu-role
   namespace: default
 ---
 apiVersion: apps/v1
@@ -57,7 +57,7 @@ spec:
       labels:
         name: amdgpu-dp-ds
     spec:
-      serviceAccount: radeon
+      serviceAccount: amd-gpu
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/k8s-ds-amdgpu-labeller.yaml
+++ b/k8s-ds-amdgpu-labeller.yaml
@@ -1,31 +1,48 @@
 # This is a configuration example for the node labeller which includes
-# ClusterRole and ClusterRoleBinding definitions, as well as the 
+# ClusterRole and ClusterRoleBinding definitions, as well as the
 # DeamonSet configuration that deploys the actual node labeller
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: cr-node-labeller
-rules:
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["watch", "get", "list", "update"]
+  name: radeon-labeller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  name: labeller
-  namespace: default
+  name: radeon-labeller-role
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - radeon-labeller-role
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - watch
+  - get
+  - list
+  - update
+  resourceNames:
+  - radeon-labeller-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: radeon-labeller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cr-node-labeller
+  kind: Role
+  name: radeon-labeller-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: radeon-labeller-role
   namespace: default
-- kind: ServiceAccount
-  name: default
-  namespace: kube-system
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -43,6 +60,7 @@ spec:
       labels:
         name: amdgpu-lr-ds
     spec:
+      serviceAccount: radeon
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/k8s-ds-amdgpu-labeller.yaml
+++ b/k8s-ds-amdgpu-labeller.yaml
@@ -4,12 +4,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: radeon-labeller
+  name: amd-gpu-labeller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: radeon-labeller-role
+  name: amd-gpu-labeller-role
 rules:
 - apiGroups:
   - policy
@@ -18,7 +18,7 @@ rules:
   verbs:
   - use
   resourceNames:
-  - radeon-labeller-role
+  - amd-gpu-labeller-role
 - apiGroups:
   - ""
   resources:
@@ -29,19 +29,19 @@ rules:
   - list
   - update
   resourceNames:
-  - radeon-labeller-role
+  - amd-gpu-labeller-role
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: radeon-labeller-rolebinding
+  name: amd-gpu-labeller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: radeon-labeller-role
+  name: amd-gpu-labeller-role
 subjects:
 - kind: ServiceAccount
-  name: radeon-labeller-role
+  name: amd-gpu-labeller-role
   namespace: default
 ---
 apiVersion: apps/v1
@@ -60,7 +60,7 @@ spec:
       labels:
         name: amdgpu-lr-ds
     spec:
-      serviceAccount: radeon
+      serviceAccount: amd-gpu
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists


### PR DESCRIPTION
Update RBAC objects to V1 and also create a serviceAccount to prevent using `Default` that is not recommended 
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>