### PR TITLE
Update broken link to ROCM docs in readme file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-FROM docker.io/golang:1.19.13-alpine3.18
+FROM docker.io/golang:1.21.6-alpine3.19
 RUN apk --no-cache add git pkgconfig build-base libdrm-dev
 RUN apk --no-cache add hwloc-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /go/src/github.com/RadeonOpenCompute/k8s-device-plugin
@@ -20,7 +20,7 @@ WORKDIR /go/src/github.com/RadeonOpenCompute/k8s-device-plugin/cmd/k8s-device-pl
 RUN go install \
     -ldflags="-X main.gitDescribe=$(git -C /go/src/github.com/RadeonOpenCompute/k8s-device-plugin/ describe --always --long --dirty)" 
 
-FROM alpine:3.18.4
+FROM alpine:3.19.0
 LABEL \
     org.opencontainers.image.source="https://github.com/RadeonOpenCompute/k8s-device-plugin" \
     org.opencontainers.image.authors="Kenny Ho <Kenny.Ho@amd.com>" \

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ kubectl create -f https://raw.githubusercontent.com/RadeonOpenCompute/k8s-devi
 [ds]: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
 [dp]: https://kubernetes.io/docs/concepts/cluster-administration/device-plugins/
 [helmamdgpu]: https://artifacthub.io/packages/helm/amd-gpu-helm/amd-gpu
-[rocm]: https://docs.amd.com/en/latest/rocm.html
+[rocm]: https://docs.amd.com/en/latest/what-is-rocm.html
 [rock]: https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
 [rocminstall]: https://docs.amd.com/en/latest/deploy/linux/quick_start.html
 [amdgpuinstall]: https://amdgpu-install.readthedocs.io/en/latest/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RadeonOpenCompute/k8s-device-plugin
 
-go 1.19
+go 1.21
 
 require (
 	github.com/go-logr/logr v1.2.3

--- a/labeller.Dockerfile
+++ b/labeller.Dockerfile
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-FROM docker.io/golang:1.19.13-alpine3.18
+FROM docker.io/golang:1.21.6-alpine3.19
 RUN apk --no-cache add git pkgconfig build-base libdrm-dev
 RUN mkdir -p /go/src/github.com/RadeonOpenCompute/k8s-device-plugin
 ADD . /go/src/github.com/RadeonOpenCompute/k8s-device-plugin
@@ -19,7 +19,7 @@ WORKDIR /go/src/github.com/RadeonOpenCompute/k8s-device-plugin/cmd/k8s-node-labe
 RUN go install \
     -ldflags="-X main.gitDescribe=$(git -C /go/src/github.com/RadeonOpenCompute/k8s-device-plugin/ describe --always --long --dirty)" 
 
-FROM alpine:3.18.4
+FROM alpine:3.19.0
 LABEL \
     org.opencontainers.image.source="https://github.com/RadeonOpenCompute/k8s-device-plugin" \
     org.opencontainers.image.authors="Kenny Ho <Kenny.Ho@amd.com>" \


### PR DESCRIPTION
It looks like the link in the Reame file that points to the ROCM docs is no longer working, i've updated it to a new working link:
 - **old:** https://docs.amd.com/en/latest/rocm.html
 - **new:** https://docs.amd.com/en/latest/what-is-rocm.html