### PR TITLE
use libdrm as fallback for fetching product name

### DIFF
--- a/cmd/k8s-node-labeller/main.go
+++ b/cmd/k8s-node-labeller/main.go
@@ -215,9 +215,17 @@ var labelGenerators = map[string]func(map[string]map[string]interface{}) map[str
 			b, err := ioutil.ReadFile(prodnamePath)
 			if err != nil {
 				log.Error(err, prodnamePath)
-				continue
 			}
 			prodName := replacer.Replace(strings.TrimSpace(string(b)))
+			// if we are not able to get the product name from sysfs, try to read the value using libdrm
+			if prodName == "" {
+				prodName, err = amdgpu.GetCardProductName(fmt.Sprintf("card%d", v["card"]))
+				if err != nil {
+					log.Error(err, prodnamePath)
+				} else {
+					prodName = replacer.Replace(strings.TrimSpace(prodName))
+				}
+			}
 			if prodName == "" {
 				continue
 			}

--- a/internal/pkg/amdgpu/amdgpu.go
+++ b/internal/pkg/amdgpu/amdgpu.go
@@ -536,3 +536,17 @@ func GetNodeIdsFromTopology(topoRootParam ...string) map[int]int {
 
 	return renderNodeIds
 }
+
+func GetCardProductName(cardName string) (string, error) {
+	devHandle, err := openAMDGPU(cardName)
+	if err != nil {
+		return "", err
+	}
+	defer C.amdgpu_device_deinitialize(devHandle)
+	productNameStr := C.amdgpu_get_marketing_name(devHandle)
+	if productNameStr == nil {
+		return "", fmt.Errorf("Failed to get product name for %s", cardName)
+	}
+	productName := C.GoString(productNameStr)
+	return productName, nil
+}

--- a/labeller.Dockerfile
+++ b/labeller.Dockerfile
@@ -12,12 +12,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 FROM docker.io/golang:1.23.6-alpine3.21
-RUN apk --no-cache add git pkgconfig build-base libdrm-dev
+RUN apk --no-cache add git pkgconfig build-base libdrm-dev wget
 RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin
 ADD . /go/src/github.com/ROCm/k8s-device-plugin
 WORKDIR /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller
 RUN go install \
     -ldflags="-X main.gitDescribe=$(git -C /go/src/github.com/ROCm/k8s-device-plugin/ describe --always --long --dirty)"
+RUN wget https://gitlab.freedesktop.org/mesa/libdrm/-/raw/main/data/amdgpu.ids
+RUN echo "74B9,   00, AMD Instinct MI325X VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "738E,   01, AMD Instinct MI100" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "73A2,   C0, AMD Radeon Pro W6900X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "73AB,   C0, AMD Radeon Pro W6800X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "74BC,   00, AMD Instinct MI308X HF VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 
 FROM alpine:3.21.3
 LABEL \
@@ -28,4 +34,5 @@ LABEL \
 RUN apk --no-cache add ca-certificates libdrm
 WORKDIR /root/
 COPY --from=0 /go/bin/k8s-node-labeller .
+COPY --from=0 /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids /usr/share/libdrm/amdgpu.ids
 CMD ["./k8s-node-labeller"]

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -29,6 +29,12 @@ ADD . /go/src/github.com/ROCm/k8s-device-plugin
 WORKDIR /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller
 RUN go install \
     -ldflags="-X main.gitDescribe=$(git -C /go/src/github.com/ROCm/k8s-device-plugin/ describe --always --long --dirty)"
+RUN wget https://gitlab.freedesktop.org/mesa/libdrm/-/raw/main/data/amdgpu.ids
+RUN echo "74B9,   00, AMD Instinct MI325X VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "738E,   01, AMD Instinct MI100" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "73A2,   C0, AMD Radeon Pro W6900X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "73AB,   C0, AMD Radeon Pro W6800X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "74BC,   00, AMD Instinct MI308X HF VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 LABEL \
@@ -45,4 +51,5 @@ RUN mkdir -p /licenses && \
 ADD ./LICENSE /licenses/LICENSE
 WORKDIR /root/
 COPY --from=builder /go/bin/k8s-node-labeller .
+COPY --from=builder /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids /usr/share/libdrm/amdgpu.ids
 CMD ["./k8s-node-labeller"]


### PR DESCRIPTION
## Motivation

In cases where nodelabeller is not able to find product name from sysfs folder, use libdrm as fallback mechanism to detect the product name.

## Technical Details



## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
