### PR TITLE
fix: exit on ListAndWatch gRPC stream disconnection

### DIFF
--- a/internal/pkg/plugin/plugin.go
+++ b/internal/pkg/plugin/plugin.go
@@ -319,6 +319,10 @@ loop:
 				}
 			}
 
+		case <-s.Context().Done():
+			glog.Errorf("ListAndWatch stream disconnected: %v, exiting to trigger re-registration", s.Context().Err())
+			os.Exit(1)
+
 		case <-p.signal:
 			glog.Infof("Received signal, exiting")
 			break loop


### PR DESCRIPTION
## Summary

- Monitor `s.Context().Done()` in the `ListAndWatch` select loop to detect gRPC stream termination
- Exit the process on disconnection so the DaemonSet controller restarts the container and re-registers with kubelet

## Problem

When the kubelet's ListAndWatch gRPC stream terminates unexpectedly (EOF), the device plugin process remains running but never re-registers with kubelet. This leaves `amd.com/gpu: 0` in node allocatable permanently until the pod is manually restarted.

The `ListAndWatch` select loop only watches `Heartbeat` and `signal` channels — it has no way to detect a broken gRPC stream. The dpm manager only restarts plugins on kubelet socket changes, which doesn't cover this scenario.

## Test plan

- [x] Built test image and deployed on OpenShift 4.21 with MI325X GPUs
- [x] Reproduced the bug (DRA → device plugin transition) — confirmed `amd.com/gpu: 0` with unpatched image
- [x] Verified fix: kubelet logs show ListAndWatch EOF at T+0, process exits, DaemonSet restarts container, re-registration at T+24s, GPUs restored

Fixes: https://github.com/ROCm/k8s-device-plugin/issues/186

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>