### PR TITLE
Add AMDGPU_FAMILY_GC_12_0_0 to FamilyIDtoString

### DIFF
--- a/internal/pkg/amdgpu/amdgpu.go
+++ b/internal/pkg/amdgpu/amdgpu.go
@@ -73,6 +73,8 @@ func FamilyIDtoString(familyId uint32) (string, error) {
 		return "GC_10_3_7", nil
 	case C.AMDGPU_FAMILY_GC_11_5_0:
 		return "GC_11_5_0", nil
+	case C.AMDGPU_FAMILY_GC_12_0_0:
+		return "GC_12_0_0", nil
 	default:
 		ret := ""
 		err := fmt.Errorf("Unknown Family ID: %d", familyId)


### PR DESCRIPTION
## Summary
- GFX12 / Navi 4x parts (e.g. Radeon AI PRO R9700, R9600D — PCI device id `0x7551`) report `family_id = 152` (`AMDGPU_FAMILY_GC_12_0_0`) via libdrm's `amdgpu_query_gpu_info`.
- `FamilyIDtoString` had no case for it, so the labeller logs `Unknown Family ID: 152` and the `amd.com/gpu.family` label is silently dropped on these nodes.
- This adds the one missing case mapping it to `"GC_12_0_0"`, matching the existing naming convention used for `GC_11_0_0`, `GC_11_5_0`, etc.

## Repro / impact
On a node with 8x R9600D (`device-id=7551`), the labeller produces every label *except* family:

```
amd.com/gpu.cu-count       = 64
amd.com/gpu.device-id      = 7551
amd.com/gpu.driver-version = 6.19.4
amd.com/gpu.product-name   = AMD_Radeon_Graphics
amd.com/gpu.simd-count     = 128
amd.com/gpu.vram           = 32G
# amd.com/gpu.family is missing
```

After this change the same node gets `amd.com/gpu.family=GC_12_0_0`.

## Compatibility
The `AMDGPU_FAMILY_GC_12_0_0` constant (value 152) is already defined in `amdgpu_drm.h` shipped by:
- `alpine:3.21` (libdrm 2.4.123) — the current `labeller.Dockerfile` base
- `alpine:3.22` / `alpine:edge`
- `ubi9` libdrm-devel

So **no base-image or libdrm bump is required**. Verified clean build inside `golang:1.23.6-alpine3.21` with `libdrm-dev`.

## Note on AMDGPU_FAMILY_GC_11_5_4 (154)
Upstream Linux master also defines `AMDGPU_FAMILY_GC_11_5_4` (154). It is intentionally **not** added here — it is not yet present in Alpine 3.21/3.22/edge libdrm headers and would break the cgo build. A follow-up can add it once Alpine bumps libdrm, optionally guarded by `#ifdef AMDGPU_FAMILY_GC_11_5_4` in the cgo preamble.

## Test plan
- [x] Builds cleanly under `golang:1.23.6-alpine3.21` + `apk add libdrm-dev` (same toolchain as `labeller.Dockerfile`)
- [ ] Deploy on an R9600D node and confirm `amd.com/gpu.family=GC_12_0_0` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)