### PR TITLE
Use ARG-based configurable base images with dev.env support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ helm/**/requirements.lock
 
 # documentation artifacts
 _build/
+
+#CI-CD
+dist/*
+
+# Local development environment overrides
+dev.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-FROM docker.io/golang:1.26.4-alpine3.23
+ARG GOLANG_BASE_IMG=golang:1.26.4-alpine3.23
+ARG ALPINE_BASE_IMG=alpine:3.23.4
+FROM ${GOLANG_BASE_IMG}
 RUN apk --no-cache add git pkgconfig build-base libdrm-dev
 RUN apk --no-cache add hwloc-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin
@@ -20,7 +22,7 @@ WORKDIR /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-device-plugin
 RUN go install \
     -ldflags="-X main.gitDescribe=$(git -C /go/src/github.com/ROCm/k8s-device-plugin/ describe --always --long --dirty)"
 
-FROM alpine:3.23.4
+FROM ${ALPINE_BASE_IMG}
 LABEL \
     org.opencontainers.image.source="https://github.com/ROCm/k8s-device-plugin" \
     org.opencontainers.image.authors="Kenny Ho <Kenny.Ho@amd.com>" \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 # Makefile for building and packaging ROCm K8s Device Plugin Docker images
 
+# Import development related environment variables from dev.env
+ifneq ("$(wildcard dev.env)","")
+    include dev.env
+endif
+
 # Use bash with pipefail to catch errors in pipe chains
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
@@ -18,6 +23,8 @@ DEVICE_PLUGIN_TAG ?= $(IMAGE_VERSION)
 LABELLER_TAG ?= labeller-$(IMAGE_VERSION)
 UBI_DEVICE_PLUGIN_TAG ?= rhubi-$(IMAGE_VERSION)
 UBI_LABELLER_TAG ?= labeller-rhubi-$(IMAGE_VERSION)
+GOLANG_BASE_IMG ?= golang:1.26.4-alpine3.23
+ALPINE_BASE_IMG ?= alpine:3.23.4
 
 # Output directory for tar.gz files
 OUTPUT_DIR ?= ./dist
@@ -41,13 +48,19 @@ save-all: save-device-plugin save-labeller save-ubi-device-plugin save-ubi-label
 # Build Alpine-based device plugin image
 build-device-plugin:
 	@echo "Building Alpine-based device plugin image..."
-	docker build -t $(IMAGE_REPO):$(DEVICE_PLUGIN_TAG) -f Dockerfile .
+	docker build -t $(IMAGE_REPO):$(DEVICE_PLUGIN_TAG) \
+		--build-arg GOLANG_BASE_IMG=$(GOLANG_BASE_IMG) \
+		--build-arg ALPINE_BASE_IMG=$(ALPINE_BASE_IMG) \
+		-f Dockerfile .
 	@echo "Built: $(IMAGE_REPO):$(DEVICE_PLUGIN_TAG)"
 
 # Build Alpine-based node labeller image
 build-labeller:
 	@echo "Building Alpine-based node labeller image..."
-	docker build -t $(IMAGE_REPO):$(LABELLER_TAG) -f labeller.Dockerfile .
+	docker build -t $(IMAGE_REPO):$(LABELLER_TAG) \
+		--build-arg GOLANG_BASE_IMG=$(GOLANG_BASE_IMG) \
+		--build-arg ALPINE_BASE_IMG=$(ALPINE_BASE_IMG) \
+		-f labeller.Dockerfile .
 	@echo "Built: $(IMAGE_REPO):$(LABELLER_TAG)"
 
 # Build UBI-based device plugin image

--- a/labeller.Dockerfile
+++ b/labeller.Dockerfile
@@ -11,7 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-FROM docker.io/golang:1.26.4-alpine3.23
+ARG GOLANG_BASE_IMG=golang:1.26.4-alpine3.23
+ARG ALPINE_BASE_IMG=alpine:3.23.4
+FROM ${GOLANG_BASE_IMG}
 RUN apk --no-cache add git pkgconfig build-base libdrm-dev wget
 RUN mkdir -p /go/src/github.com/ROCm/k8s-device-plugin
 ADD . /go/src/github.com/ROCm/k8s-device-plugin
@@ -25,7 +27,7 @@ RUN echo "73A2,   C0, AMD Radeon Pro W6900X" >> /go/src/github.com/ROCm/k8s-devi
 RUN echo "73AB,   C0, AMD Radeon Pro W6800X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "74BC,   00, AMD Instinct MI308X HF VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 
-FROM alpine:3.23.4
+FROM ${ALPINE_BASE_IMG}
 LABEL \
     org.opencontainers.image.source="https://github.com/ROCm/k8s-device-plugin" \
     org.opencontainers.image.authors="Kenny Ho <Kenny.Ho@amd.com>" \


### PR DESCRIPTION
## Summary
- Replaces hardcoded \`FROM docker.io/golang:...\` and \`FROM alpine:...\` with \`ARG\`-based variables in \`Dockerfile\` and \`labeller.Dockerfile\`
- Adds \`GOLANG_BASE_IMG\` and \`ALPINE_BASE_IMG\` vars to \`Makefile\` with public Docker Hub defaults, passed as \`--build-arg\` to the Alpine image builds
- \`Makefile\` optionally includes a \`dev.env\` file (gitignored) where these can be overridden to point at a private registry, avoiding Docker Hub rate limit errors in CI