### PR TITLE
Add Radeon AI PRO R9700S, R9600D, and W7900S GPU entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI - Build Images
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: device-plugin
+            target: build-device-plugin
+          - name: labeller
+            target: build-labeller
+          - name: ubi-device-plugin
+            target: build-ubi-device-plugin
+          - name: ubi-labeller
+            target: build-ubi-labeller
+    name: build (${{ matrix.name }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.name }}
+        run: make ${{ matrix.target }}

--- a/labeller.Dockerfile
+++ b/labeller.Dockerfile
@@ -24,6 +24,7 @@ RUN echo "738E,   01, AMD Instinct MI100" >> /go/src/github.com/ROCm/k8s-device-
 RUN echo "73A2,   C0, AMD Radeon Pro W6900X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "73AB,   C0, AMD Radeon Pro W6800X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "74BC,   00, AMD Instinct MI308X HF VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "7551,   C1, AMD Radeon AI PRO R9700S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 
 FROM alpine:3.23.4
 LABEL \

--- a/labeller.Dockerfile
+++ b/labeller.Dockerfile
@@ -26,7 +26,7 @@ RUN echo "73AB,   C0, AMD Radeon Pro W6800X" >> /go/src/github.com/ROCm/k8s-devi
 RUN echo "74BC,   00, AMD Instinct MI308X HF VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "7551,   C1, AMD Radeon AI PRO R9700S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "7551,   C8, AMD Radeon AI PRO R9600D" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
-RUN echo "744A,   00, AMD Radeon PRO W7900S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "744A,   00, AMD Radeon PRO W7900 Dual Slot" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 
 FROM alpine:3.23.4
 LABEL \

--- a/labeller.Dockerfile
+++ b/labeller.Dockerfile
@@ -25,6 +25,8 @@ RUN echo "73A2,   C0, AMD Radeon Pro W6900X" >> /go/src/github.com/ROCm/k8s-devi
 RUN echo "73AB,   C0, AMD Radeon Pro W6800X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "74BC,   00, AMD Instinct MI308X HF VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "7551,   C1, AMD Radeon AI PRO R9700S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "7551,   C8, AMD Radeon AI PRO R9600D" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "744A,   00, AMD Radeon PRO W7900S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 
 FROM alpine:3.23.4
 LABEL \

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -37,7 +37,7 @@ RUN echo "73AB,   C0, AMD Radeon Pro W6800X" >> /go/src/github.com/ROCm/k8s-devi
 RUN echo "74BC,   00, AMD Instinct MI308X HF VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "7551,   C1, AMD Radeon AI PRO R9700S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "7551,   C8, AMD Radeon AI PRO R9600D" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
-RUN echo "744A,   00, AMD Radeon PRO W7900S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "744A,   00, AMD Radeon PRO W7900 Dual Slot" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 LABEL \

--- a/ubi-labeller.Dockerfile
+++ b/ubi-labeller.Dockerfile
@@ -35,6 +35,9 @@ RUN echo "738E,   01, AMD Instinct MI100" >> /go/src/github.com/ROCm/k8s-device-
 RUN echo "73A2,   C0, AMD Radeon Pro W6900X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "73AB,   C0, AMD Radeon Pro W6800X" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 RUN echo "74BC,   00, AMD Instinct MI308X HF VF" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "7551,   C1, AMD Radeon AI PRO R9700S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "7551,   C8, AMD Radeon AI PRO R9600D" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
+RUN echo "744A,   00, AMD Radeon PRO W7900S" >> /go/src/github.com/ROCm/k8s-device-plugin/cmd/k8s-node-labeller/amdgpu.ids
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 LABEL \


### PR DESCRIPTION
## Summary
- Adds amdgpu.ids entries in the node labeller for Radeon AI PRO R9700S (7551, C1), R9600D (7551, C8), and Radeon PRO W7900S (744A, 00)
- Adds amdgpu.ids entry in the device plugin container image for R9700S (7551, C1)
- These entries are not yet in upstream libdrm, so hardcoding them ensures correct GPU product name resolution