### PR TITLE
fix(security): bump Go 1.26.4 → 1.26.5 for CVE-2026-39822

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-ARG GOLANG_BASE_IMG=golang:1.26.4-alpine3.23
+ARG GOLANG_BASE_IMG=golang:1.26.5-alpine3.23
 ARG ALPINE_BASE_IMG=alpine:3.23.5
 FROM ${GOLANG_BASE_IMG}
 RUN apk --no-cache add git pkgconfig build-base libdrm-dev

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DEVICE_PLUGIN_TAG ?= $(IMAGE_VERSION)
 LABELLER_TAG ?= labeller-$(IMAGE_VERSION)
 UBI_DEVICE_PLUGIN_TAG ?= rhubi-$(IMAGE_VERSION)
 UBI_LABELLER_TAG ?= labeller-rhubi-$(IMAGE_VERSION)
-GOLANG_BASE_IMG ?= golang:1.26.4-alpine3.23
+GOLANG_BASE_IMG ?= golang:1.26.5-alpine3.23
 ALPINE_BASE_IMG ?= alpine:3.23.5
 
 # Output directory for tar.gz files

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ROCm/k8s-device-plugin
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary

- Bump Go from 1.26.4 to 1.26.5 to fix **CVE-2026-39822** (HIGH — `os.Root` symlink following vulnerability allows directory traversal)
- Updated: `go.mod`, `Dockerfile`, `Makefile`

## CVE Details

| CVE | Severity | Package | Fixed In |
|-----|----------|---------|----------|
| [CVE-2026-39822](https://avd.aquasec.com/nvd/cve-2026-39822) | HIGH | Go stdlib (`os` package) | Go 1.26.5 |

## Test plan

- [ ] `make build-device-plugin` builds successfully
- [ ] Trivy re-scan confirms CVE resolved
- [ ] CI passes