### PR TITLE
docs: note exporter service name alignment requirement

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -69,6 +69,10 @@ nodeSelector: {} # Optional: Add custom nodeSelector
 image:
   repository: docker.io/rocm/device-metrics-exporter
   tag: v1.2.0
+  # Note: versions before the fix in ROCm/device-metrics-exporter#586
+  # expose the gRPC service as gpumetricssvc.MetricsService, which the
+  # device plugin cannot use. Use an image built after that merge, or
+  # use the host's systemd-managed exporter instead.
   pullPolicy: Always
 service:
   type: ClusterIP


### PR DESCRIPTION
## What

The container metrics exporter image must expose `metricssvc.MetricsService`
to be compatible with the device plugin health-check path. Versions
before [ROCm/device-metrics-exporter#586](https://github.com/ROCm/device-metrics-exporter/pull/586) used `gpumetricssvc.MetricsService`,
which caused gRPC `unimplemented` errors during health checks.

## Changes

- `docs/user-guide/installation.md`: added a comment in the Helm values
  example pointing users to the fixed exporter image or the host
  systemd-managed exporter as alternatives.

## Related

- ROCm/device-metrics-exporter#586 — fixes the service name in the container exporter
- ROCm/k8s-device-plugin#205 — this issue