### PR TITLE
Add llms.txt generation and markdown download button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,16 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
+"""Configuration file for the Sphinx documentation builder."""
+import os
 
 external_projects_local_file = "projects.yaml"
 external_projects_remote_repository = ""
 #external_projects = ["k8s-device-plugin"]
 external_projects = []
 external_projects_current_project = "k8s-device-plugin"
+
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "instinct.docs.amd.com")
+html_context = {}
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
 
 project = "AMD Kubernetes Device Plugin Documentation"
 version = "1.3.1"
@@ -21,12 +22,18 @@ copyright = "Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved
 # Required settings
 html_theme = "rocm_docs_theme"
 html_theme_options = {
-    "flavor": "instinct"
+    "flavor": "instinct",
+    "link_main_doc": True,
+    "use_download_button": True,
 }
 extensions = ["rocm_docs"]
 
 external_toc_path = "./sphinx/_toc.yml"
 
-extensions = ["rocm_docs"]
-
 exclude_patterns = ['.venv']
+
+
+# Generate llms.txt and llms-full.txt after each build (the llms.txt standard,
+# https://llmstxt.org/). See the rocm-docs-core guide:
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/user_guide/llms.html
+rocm_docs_generate_llms = True

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core==1.38.0
+rocm-docs-core[llms]==1.38.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -51,6 +51,7 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-markdown-builder
 exceptiongroup==1.2.2
     # via ipython
 executing==2.1.0
@@ -188,7 +189,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.38.0
+rocm-docs-core[llms]==1.38.0
     # via -r requirements.in
 rpds-py==0.22.3
     # via
@@ -213,6 +214,7 @@ sphinx==8.0.2
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-markdown-builder
     #   sphinx-notfound-page
 sphinx-book-theme==1.1.4
     # via rocm-docs-core
@@ -221,6 +223,8 @@ sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
     # via rocm-docs-core
 sphinx-external-toc==1.0.1
+    # via rocm-docs-core
+sphinx-markdown-builder==0.6.10
     # via rocm-docs-core
 sphinx-notfound-page==1.0.4
     # via rocm-docs-core
@@ -241,7 +245,9 @@ sqlalchemy==2.0.37
 stack-data==0.6.3
     # via ipython
 tabulate==0.9.0
-    # via jupyter-cache
+    # via
+    #   jupyter-cache
+    #   sphinx-markdown-builder
 tomli==2.0.1
     # via sphinx
 tornado==6.4.2


### PR DESCRIPTION
## Motivation

Enable and simplify llms.txt / llms-full.txt generation for the Kubernetes Device Plugin docs, so the site publishes machine-readable documentation following the llms.txt standard (https://llmstxt.org/). This aligns the project with the shared approach now used across the Instinct documentation set, using the built-in support in rocm-docs-core instead of a bespoke, hand-maintained script.

## Technical Details

- Enable generation via the built-in rocm_docs_generate_llms = True in docs/conf.py, which produces both llms.txt and llms-full.txt from the resolved doctree at build time.
- Remove the custom generate_combined_markdown generator (and its regex/prose-filtering helpers, html_extra_path entry, and build-finished hook) from conf.py in favor of the maintained implementation in rocm-docs-core.
- Drop the manually curated static docs/llms.txt; it is now generated.
- Bump rocm-docs-core to 1.38.0 and add the [llms] extra in docs/sphinx/requirements.in; regenerate requirements.txt (Python 3.10, matching .readthedocs.yaml), which pulls in sphinx-markdown-builder and rpds-py.

## Test Plan

- Build the docs locally / via Read the Docs and confirm the build completes with the new dependency set.
- Verify llms.txt and llms-full.txt are produced in the build output and are reachable at the site root.
- Spot-check llms-full.txt content: correct base header, per-page sections, and that markup (RST/MyST directives, raw HTML) is filtered out of prose.
- Confirm the per-page Markdown download button still renders.

## Test Result

With rocm-docs-core[llms]==1.38.0, a full sphinx-build -b html in a clean Python 3.10 container (matching .readthedocs.yaml) succeeds and logs Wrote llms.txt and llms-full.txt. Generated llms.txt (656 B) indexes all five pages; llms-full.txt (~30 KB) has correct per-page sections with prose filtering. 1.39.0 was avoided because its published wheel ships a malformed projects.yaml that breaks the build (already fixed upstream on develop, pending a patch release).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
